### PR TITLE
Use config properties with hyphens to prevent verification clashes in the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Given a JSON config file (`config.json`)...
 
 ``` json
 {
-  "account-name":           "<string> (required)",
-  "account-key":            "<string> (required)",
-  "container-name":         "<string> (required)"
+  "account_name":           "<string> (required)",
+  "account_key":            "<string> (required)",
+  "container_name":         "<string> (required)"
 }
 ```
 

--- a/config/config.go
+++ b/config/config.go
@@ -6,9 +6,9 @@ import (
 )
 
 type AZStorageConfig struct {
-	AccountName   string `json:"account-name"`
-	AccountKey    string `json:"account-key"`
-	ContainerName string `json:"container-name"`
+	AccountName   string `json:"account_name"`
+	AccountKey    string `json:"account_key"`
+	ContainerName string `json:"container_name"`
 }
 
 // NewFromReader returns a new azure-storage-cli configuration struct from the contents of reader.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,9 +11,9 @@ import (
 var _ = Describe("Config", func() {
 
 	It("contains account-name and account-name", func() {
-		configJson := []byte(`{"account-name": "foo-account-name", 
-								"account-key": "bar-account-key", 
-								"container-name": "baz-container-name"}`)
+		configJson := []byte(`{"account_name": "foo-account-name",
+								"account_key": "bar-account-key",
+								"container_name": "baz-container-name"}`)
 		configReader := bytes.NewReader(configJson)
 
 		config, err := config.NewFromReader(configReader)


### PR DESCRIPTION
This PR prevents issues while switching to the external blobstore caused due to clashes with the agent configuration in the bosh-director code due to mismatched config properties