### PR TITLE
Putting a file fails on MD5 mismatches

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.19.2
+golang 1.21.0

--- a/client/client.go
+++ b/client/client.go
@@ -1,7 +1,11 @@
 package client
 
 import (
+	"bytes"
+	"crypto/md5"
 	"fmt"
+	"io"
+	"log"
 	"os"
 	"strings"
 	"time"
@@ -15,9 +19,37 @@ func New(storageClient StorageClient) (AzBlobstore, error) {
 	return AzBlobstore{storageClient: storageClient}, nil
 }
 
-func (client *AzBlobstore) Put(source *os.File, dest string) error {
+func (client *AzBlobstore) Put(sourceFilePath string, dest string) error {
+	sourceMD5, err:= client.getMD5(sourceFilePath)
+	if err != nil {
+		return err
+	}
 
-	return client.storageClient.Upload(source, dest)
+	source, err := os.Open(sourceFilePath)
+	if err != nil {
+		return err
+	}
+
+	defer source.Close()
+
+	md5, err := client.storageClient.Upload(source, dest)
+	if err != nil {
+		return fmt.Errorf("upload failure: %w", err)
+	}
+
+	if !bytes.Equal(sourceMD5, md5) {
+		log.Println("The upload failed because of an MD5 inconsistency. Triggering blob deletion ...")
+
+		err := client.storageClient.Delete(dest)
+		if err != nil {
+			log.Println(fmt.Errorf("blob deletion failed: %w", err))
+		}
+
+		return fmt.Errorf("the upload responded an MD5 %v does not match the source file MD5 %v", md5, sourceMD5)
+	}
+
+	log.Println("Successfully uploaded file")
+	return nil
 }
 
 func (client *AzBlobstore) Get(source string, dest *os.File) error {
@@ -43,4 +75,23 @@ func (client *AzBlobstore) Sign(dest string, action string, expiration time.Dura
 	default:
 		return "", fmt.Errorf("action not implemented: %s", action)
 	}
+}
+
+
+func (client *AzBlobstore) getMD5(filePath string) ([]byte, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	defer file.Close()
+
+
+	hash := md5.New()
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to calculate md5: %w", err)
+	}
+
+	return hash.Sum(nil), nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -11,21 +11,57 @@ import (
 
 var _ = Describe("Client", func() {
 
-	It("put file uploads to a blob", func() {
-		storageClient := clientfakes.FakeStorageClient{}
+	Context("Put", func() {
+		It("uploads a file to a blob", func() {
+			storageClient := clientfakes.FakeStorageClient{}
 
-		azBlobstore, err := client.New(&storageClient)
-		Expect(err).ToNot(HaveOccurred())
+			azBlobstore, err := client.New(&storageClient)
+			Expect(err).ToNot(HaveOccurred())
 
-		file, _ := os.CreateTemp("", "tmpfile")
+			file, _ := os.CreateTemp("", "tmpfile")
 
-		azBlobstore.Put(file, "target/blob")
+			azBlobstore.Put(file.Name(), "target/blob")
 
-		Expect(storageClient.UploadCallCount()).To(Equal(1))
-		source, dest := storageClient.UploadArgsForCall(0)
+			Expect(storageClient.UploadCallCount()).To(Equal(1))
+			source, dest := storageClient.UploadArgsForCall(0)
 
-		Expect(source).To(Equal(file))
-		Expect(dest).To(Equal("target/blob"))
+			Expect(source).To(BeAssignableToTypeOf((*os.File)(nil)))
+			Expect(dest).To(Equal("target/blob"))
+		})
+
+		It("skips the upload if the md5 cannot be calculated from the file", func() {
+			storageClient := clientfakes.FakeStorageClient{}
+
+			azBlobstore, err := client.New(&storageClient)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = azBlobstore.Put("the/path", "target/blob")
+
+			Expect(storageClient.UploadCallCount()).To(Equal(0))
+			Expect(err.Error()).To(Equal("open the/path: no such file or directory"))
+		})
+
+		It("fails if the source file md5 does not match the responded md5", func() {
+			storageClient := clientfakes.FakeStorageClient{}
+			storageClient.UploadReturns([]byte{1, 2, 3}, nil)
+
+			azBlobstore, err := client.New(&storageClient)
+			Expect(err).ToNot(HaveOccurred())
+
+			file, _ := os.CreateTemp("", "tmpfile")
+
+			putError := azBlobstore.Put(file.Name(), "target/blob")
+			Expect(putError.Error()).To(Equal("the upload responded an MD5 [1 2 3] does not match the source file MD5 [212 29 140 217 143 0 178 4 233 128 9 152 236 248 66 126]"))
+
+			Expect(storageClient.UploadCallCount()).To(Equal(1))
+			source, dest := storageClient.UploadArgsForCall(0)
+			Expect(source).To(BeAssignableToTypeOf((*os.File)(nil)))
+			Expect(dest).To(Equal("target/blob"))
+
+			Expect(storageClient.DeleteCallCount()).To(Equal(1))
+			dest = storageClient.DeleteArgsForCall(0)
+			Expect(dest).To(Equal("target/blob"))
+		})
 	})
 
 	It("get blob downloads to a file", func() {

--- a/client/clientfakes/fake_storage_client.go
+++ b/client/clientfakes/fake_storage_client.go
@@ -61,17 +61,19 @@ type FakeStorageClient struct {
 		result1 string
 		result2 error
 	}
-	UploadStub        func(io.ReadSeekCloser, string) error
+	UploadStub        func(io.ReadSeekCloser, string) ([]byte, error)
 	uploadMutex       sync.RWMutex
 	uploadArgsForCall []struct {
 		arg1 io.ReadSeekCloser
 		arg2 string
 	}
 	uploadReturns struct {
-		result1 error
+		result1 []byte
+		result2 error
 	}
 	uploadReturnsOnCall map[int]struct {
-		result1 error
+		result1 []byte
+		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -329,7 +331,7 @@ func (fake *FakeStorageClient) SignedUrlReturnsOnCall(i int, result1 string, res
 	}{result1, result2}
 }
 
-func (fake *FakeStorageClient) Upload(arg1 io.ReadSeekCloser, arg2 string) error {
+func (fake *FakeStorageClient) Upload(arg1 io.ReadSeekCloser, arg2 string) ([]byte, error) {
 	fake.uploadMutex.Lock()
 	ret, specificReturn := fake.uploadReturnsOnCall[len(fake.uploadArgsForCall)]
 	fake.uploadArgsForCall = append(fake.uploadArgsForCall, struct {
@@ -344,9 +346,9 @@ func (fake *FakeStorageClient) Upload(arg1 io.ReadSeekCloser, arg2 string) error
 		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeStorageClient) UploadCallCount() int {
@@ -355,7 +357,7 @@ func (fake *FakeStorageClient) UploadCallCount() int {
 	return len(fake.uploadArgsForCall)
 }
 
-func (fake *FakeStorageClient) UploadCalls(stub func(io.ReadSeekCloser, string) error) {
+func (fake *FakeStorageClient) UploadCalls(stub func(io.ReadSeekCloser, string) ([]byte, error)) {
 	fake.uploadMutex.Lock()
 	defer fake.uploadMutex.Unlock()
 	fake.UploadStub = stub
@@ -368,27 +370,30 @@ func (fake *FakeStorageClient) UploadArgsForCall(i int) (io.ReadSeekCloser, stri
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeStorageClient) UploadReturns(result1 error) {
+func (fake *FakeStorageClient) UploadReturns(result1 []byte, result2 error) {
 	fake.uploadMutex.Lock()
 	defer fake.uploadMutex.Unlock()
 	fake.UploadStub = nil
 	fake.uploadReturns = struct {
-		result1 error
-	}{result1}
+		result1 []byte
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeStorageClient) UploadReturnsOnCall(i int, result1 error) {
+func (fake *FakeStorageClient) UploadReturnsOnCall(i int, result1 []byte, result2 error) {
 	fake.uploadMutex.Lock()
 	defer fake.uploadMutex.Unlock()
 	fake.UploadStub = nil
 	if fake.uploadReturnsOnCall == nil {
 		fake.uploadReturnsOnCall = make(map[int]struct {
-			result1 error
+			result1 []byte
+			result2 error
 		})
 	}
 	fake.uploadReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
+		result1 []byte
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeStorageClient) Invocations() map[string][][]interface{} {

--- a/integration/assertions.go
+++ b/integration/assertions.go
@@ -50,24 +50,6 @@ func AssertLifecycleWorks(cliPath string, cfg *config.AZStorageConfig) {
 	Expect(cliSession.Err.Contents()).To(MatchRegexp("File '.*' does not exist in bucket '.*'"))
 }
 
-func AssertOnPutFailures(cliPath string, cfg *config.AZStorageConfig, errorMessage string) {
-	expectedString := GenerateRandomString()
-	blobName := GenerateRandomString()
-
-	configPath := MakeConfigFile(cfg)
-	defer func() { _ = os.Remove(configPath) }()
-
-	contentFile := MakeContentFile(expectedString)
-	defer func() { _ = os.Remove(contentFile) }()
-
-	cliSession, err := RunCli(cliPath, configPath, "put", contentFile, blobName)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(cliSession.ExitCode()).To(Equal(1))
-
-	consoleOutput := bytes.NewBuffer(cliSession.Err.Contents()).String()
-	Expect(consoleOutput).To(ContainSubstring(errorMessage))
-}
-
 func AssertOnCliVersion(cliPath string, cfg *config.AZStorageConfig) {
 	configPath := MakeConfigFile(cfg)
 	defer func() { _ = os.Remove(configPath) }()

--- a/integration/general_azure_test.go
+++ b/integration/general_azure_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"bytes"
 	"os"
 
 	"github.com/cloudfoundry/bosh-azure-storage-cli/config"
@@ -11,24 +12,15 @@ import (
 )
 
 var _ = Describe("General testing for all Azure regions", func() {
-	accountName := os.Getenv("ACCOUNT_NAME")
-
-	accountKey := os.Getenv("ACCOUNT_KEY")
-
-	containerName := os.Getenv("CONTAINER_NAME")
 
 	BeforeEach(func() {
-		Expect(accountName).ToNot(BeEmpty(), "ACCOUNT_NAME must be set")
-		Expect(accountKey).ToNot(BeEmpty(), "ACCOUNT_KEY must be set")
-		Expect(containerName).ToNot(BeEmpty(), "CONTAINER_NAME must be set")
+		Expect(os.Getenv("ACCOUNT_NAME")).ToNot(BeEmpty(), "ACCOUNT_NAME must be set")
+		Expect(os.Getenv("ACCOUNT_KEY")).ToNot(BeEmpty(), "ACCOUNT_KEY must be set")
+		Expect(os.Getenv("CONTAINER_NAME")).ToNot(BeEmpty(), "CONTAINER_NAME must be set")
 	})
 
 	configurations := []TableEntry{
-		Entry("with default config", &config.AZStorageConfig{
-			AccountName:   accountName,
-			AccountKey:    accountKey,
-			ContainerName: containerName,
-		}),
+		Entry("with default config", defaultConfig()),
 	}
 	DescribeTable("Blobstore lifecycle works",
 		func(cfg *config.AZStorageConfig) { integration.AssertLifecycleWorks(cliPath, cfg) },
@@ -46,25 +38,104 @@ var _ = Describe("General testing for all Azure regions", func() {
 		func(cfg *config.AZStorageConfig) { integration.AssertOnSignedURLs(cliPath, cfg) },
 		configurations,
 	)
-	Describe("Invoking `put` with arbitrary upload failures", func() {
+	Describe("Invoking `put`", func() {
+		var blobName string
+		var configPath string
+		var contentFile string
+
+		BeforeEach(func() {
+			blobName = integration.GenerateRandomString()
+			configPath = integration.MakeConfigFile(defaultConfig())
+			contentFile = integration.MakeContentFile("foo")
+		})
+
+		AfterEach(func() {
+			defer func() { _ = os.Remove(configPath) }()
+			defer func() { _ = os.Remove(contentFile) }()
+		})
+
+		It("uploads a file", func() {
+			defer func() {
+				cliSession, err := integration.RunCli(cliPath, configPath, "delete", blobName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cliSession.ExitCode()).To(BeZero())
+			}()
+
+			cliSession, err := integration.RunCli(cliPath, configPath, "put", contentFile, blobName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cliSession.ExitCode()).To(BeZero())
+
+			cliSession, err = integration.RunCli(cliPath, configPath, "exists", blobName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cliSession.ExitCode()).To(BeZero())
+			Expect(string(cliSession.Err.Contents())).To(MatchRegexp("File '" + blobName + "' exists in bucket 'test-container'"))
+		})
+
+		It("overwrites an existing file", func() {
+			defer func() {
+				cliSession, err := integration.RunCli(cliPath, configPath, "delete", blobName)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cliSession.ExitCode()).To(BeZero())
+			}()
+
+			tmpLocalFile, _ := os.CreateTemp("", "azure-storage-cli-download")
+			tmpLocalFile.Close()
+			defer func() { _ = os.Remove(tmpLocalFile.Name()) }()
+
+			contentFile = integration.MakeContentFile("initial content")
+			cliSession, err := integration.RunCli(cliPath, configPath, "put", contentFile, blobName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cliSession.ExitCode()).To(BeZero())
+
+			cliSession, err = integration.RunCli(cliPath, configPath, "get", blobName, tmpLocalFile.Name())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cliSession.ExitCode()).To(BeZero())
+
+			gottenBytes, _ := os.ReadFile(tmpLocalFile.Name())
+			Expect(string(gottenBytes)).To(Equal("initial content"))
+
+			contentFile = integration.MakeContentFile("updated content")
+			cliSession, err = integration.RunCli(cliPath, configPath, "put", contentFile, blobName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cliSession.ExitCode()).To(BeZero())
+
+			cliSession, err = integration.RunCli(cliPath, configPath, "get", blobName, tmpLocalFile.Name())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cliSession.ExitCode()).To(BeZero())
+
+			gottenBytes, _ = os.ReadFile(tmpLocalFile.Name())
+			Expect(string(gottenBytes)).To(Equal("updated content"))
+		})
+
 		It("returns the appropriate error message", func() {
 			cfg := &config.AZStorageConfig{
-				AccountName:   accountName,
-				AccountKey:    accountKey,
+				AccountName:   os.Getenv("ACCOUNT_NAME"),
+				AccountKey:    os.Getenv("ACCOUNT_KEY"),
 				ContainerName: "not-existing",
 			}
-			msg := "upload failure"
-			integration.AssertOnPutFailures(cliPath, cfg, msg)
+
+			configPath = integration.MakeConfigFile(cfg)
+
+			cliSession, err := integration.RunCli(cliPath, configPath, "put", contentFile, blobName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cliSession.ExitCode()).To(Equal(1))
+
+			consoleOutput := bytes.NewBuffer(cliSession.Err.Contents()).String()
+			Expect(consoleOutput).To(ContainSubstring("upload failure"))
 		})
 	})
 	Describe("Invoking `-v`", func() {
 		It("returns the cli version", func() {
-			cfg := &config.AZStorageConfig{
-				AccountName:   accountName,
-				AccountKey:    accountKey,
-				ContainerName: containerName,
-			}
-			integration.AssertOnCliVersion(cliPath, cfg)
+			integration.AssertOnCliVersion(cliPath, defaultConfig())
 		})
 	})
 })
+
+func defaultConfig() *config.AZStorageConfig {
+
+	return &config.AZStorageConfig{
+		AccountName:   os.Getenv("ACCOUNT_NAME"),
+		AccountKey:    os.Getenv("ACCOUNT_KEY"),
+		ContainerName: os.Getenv("CONTAINER_NAME"),
+	}
+}

--- a/main.go
+++ b/main.go
@@ -55,17 +55,15 @@ func main() {
 		if len(nonFlagArgs) != 3 {
 			log.Fatalf("Put method expected 3 arguments got %d\n", len(nonFlagArgs))
 		}
-		src, dst := nonFlagArgs[1], nonFlagArgs[2]
+		sourceFilePath, dst := nonFlagArgs[1], nonFlagArgs[2]
 
-		var sourceFile *os.File
-		sourceFile, err = os.Open(src)
+		_, err := os.Stat(sourceFilePath)
 		if err != nil {
 			log.Fatalln(err)
 		}
 
-		defer sourceFile.Close()
-
-		err = blobstoreClient.Put(sourceFile, dst)
+		err = blobstoreClient.Put(sourceFilePath, dst)
+		fatalLog(cmd, err)
 
 	case "get":
 		if len(nonFlagArgs) != 3 {
@@ -82,6 +80,7 @@ func main() {
 		defer dstFile.Close()
 
 		err = blobstoreClient.Get(src, dstFile)
+		fatalLog(cmd, err)
 
 	case "delete":
 		if len(nonFlagArgs) != 2 {
@@ -89,6 +88,7 @@ func main() {
 		}
 
 		err = blobstoreClient.Delete(nonFlagArgs[1])
+		fatalLog(cmd, err)
 
 	case "exists":
 		if len(nonFlagArgs) != 2 {
@@ -124,7 +124,6 @@ func main() {
 
 		if err != nil {
 			log.Fatalf("Failed to sign request: %s", err)
-			os.Exit(1)
 		}
 
 		fmt.Println(signedURL)
@@ -133,8 +132,11 @@ func main() {
 	default:
 		log.Fatalf("unknown command: '%s'\n", cmd)
 	}
+}
 
+func fatalLog(cmd string, err error) {
 	if err != nil {
 		log.Fatalf("performing operation %s: %s\n", cmd, err)
 	}
 }
+


### PR DESCRIPTION
If the Azure Storage upload responds an MD5 that is not matching the MD5 of the uploaded file, then the executed put command returns an error