### PR TITLE
set server-side timeout for GET requests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -71,7 +71,7 @@ func (client *AzBlobstore) Sign(dest string, action string, expiration time.Dura
 	action = strings.ToUpper(action)
 	switch action {
 	case "GET", "PUT":
-		return client.storageClient.SignedUrl(dest, expiration)
+		return client.storageClient.SignedUrl(action, dest, expiration)
 	default:
 		return "", fmt.Errorf("action not implemented: %s", action)
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -146,7 +146,8 @@ var _ = Describe("Client", func() {
 			Expect(url == "https://the-signed-url").To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
 
-			dest, expiration := storageClient.SignedUrlArgsForCall(0)
+			action, dest, expiration := storageClient.SignedUrlArgsForCall(0)
+			Expect(action).To(Equal("GET"))
 			Expect(dest).To(Equal("blob"))
 			Expect(int(expiration)).To(Equal(100))
 		})

--- a/client/clientfakes/fake_storage_client.go
+++ b/client/clientfakes/fake_storage_client.go
@@ -47,11 +47,12 @@ type FakeStorageClient struct {
 		result1 bool
 		result2 error
 	}
-	SignedUrlStub        func(string, time.Duration) (string, error)
+	SignedUrlStub        func(string, string, time.Duration) (string, error)
 	signedUrlMutex       sync.RWMutex
 	signedUrlArgsForCall []struct {
 		arg1 string
-		arg2 time.Duration
+		arg2 string
+		arg3 time.Duration
 	}
 	signedUrlReturns struct {
 		result1 string
@@ -266,19 +267,20 @@ func (fake *FakeStorageClient) ExistsReturnsOnCall(i int, result1 bool, result2 
 	}{result1, result2}
 }
 
-func (fake *FakeStorageClient) SignedUrl(arg1 string, arg2 time.Duration) (string, error) {
+func (fake *FakeStorageClient) SignedUrl(arg1 string, arg2 string, arg3 time.Duration) (string, error) {
 	fake.signedUrlMutex.Lock()
 	ret, specificReturn := fake.signedUrlReturnsOnCall[len(fake.signedUrlArgsForCall)]
 	fake.signedUrlArgsForCall = append(fake.signedUrlArgsForCall, struct {
 		arg1 string
-		arg2 time.Duration
-	}{arg1, arg2})
+		arg2 string
+		arg3 time.Duration
+	}{arg1, arg2, arg3})
 	stub := fake.SignedUrlStub
 	fakeReturns := fake.signedUrlReturns
-	fake.recordInvocation("SignedUrl", []interface{}{arg1, arg2})
+	fake.recordInvocation("SignedUrl", []interface{}{arg1, arg2, arg3})
 	fake.signedUrlMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -292,17 +294,17 @@ func (fake *FakeStorageClient) SignedUrlCallCount() int {
 	return len(fake.signedUrlArgsForCall)
 }
 
-func (fake *FakeStorageClient) SignedUrlCalls(stub func(string, time.Duration) (string, error)) {
+func (fake *FakeStorageClient) SignedUrlCalls(stub func(string, string, time.Duration) (string, error)) {
 	fake.signedUrlMutex.Lock()
 	defer fake.signedUrlMutex.Unlock()
 	fake.SignedUrlStub = stub
 }
 
-func (fake *FakeStorageClient) SignedUrlArgsForCall(i int) (string, time.Duration) {
+func (fake *FakeStorageClient) SignedUrlArgsForCall(i int) (string, string, time.Duration) {
 	fake.signedUrlMutex.RLock()
 	defer fake.signedUrlMutex.RUnlock()
 	argsForCall := fake.signedUrlArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeStorageClient) SignedUrlReturns(result1 string, result2 error) {

--- a/client/storage_client.go
+++ b/client/storage_client.go
@@ -37,6 +37,7 @@ type StorageClient interface {
 	) (bool, error)
 
 	SignedUrl(
+		requestType string,
 		dest string,
 		expiration time.Duration,
 	) (string, error)
@@ -152,6 +153,7 @@ func (dsc DefaultStorageClient) Exists(
 }
 
 func (dsc DefaultStorageClient) SignedUrl(
+	requestType string,
 	dest string,
 	expiration time.Duration,
 ) (string, error) {
@@ -167,6 +169,10 @@ func (dsc DefaultStorageClient) SignedUrl(
 	url, err := client.GetSASURL(sas.BlobPermissions{Read: true, Create: true}, time.Now().Add(expiration), nil)
 	if err != nil {
 		return "", err
+	}
+
+	if requestType == "GET" {
+		url = url + "&timeout=1800"
 	}
 
 	return url, err

--- a/client/storage_client.go
+++ b/client/storage_client.go
@@ -171,8 +171,12 @@ func (dsc DefaultStorageClient) SignedUrl(
 		return "", err
 	}
 
+	// There could be occasional issues with the Azure Storage Account when requests hitting
+	// the server are not responded to, and then BOSH hangs while expecting a reply from the server.
+	// That's why we implement a server-side timeout here
+	// (see: https://learn.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-blob-service-operations)
 	if requestType == "GET" {
-		url = url + "&timeout=1800"
+		url += "&timeout=1800"
 	}
 
 	return url, err

--- a/client/storage_client.go
+++ b/client/storage_client.go
@@ -173,11 +173,13 @@ func (dsc DefaultStorageClient) SignedUrl(
 
 	// There could be occasional issues with the Azure Storage Account when requests hitting
 	// the server are not responded to, and then BOSH hangs while expecting a reply from the server.
-	// That's why we implement a server-side timeout here
+	// That's why we implement a server-side timeout here (30 mins for GET and 45 mins for PUT)
 	// (see: https://learn.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-blob-service-operations)
 	if requestType == "GET" {
 		url += "&timeout=1800"
-	}
+	} else {
+        url += "&timeout=2700"
+    }
 
 	return url, err
 }


### PR DESCRIPTION
Recently, there have been hanging bosh tasks while fetching blobs from Azure storage account containers. Basically, Azure sometimes simply does not respond to these GET requests, not even with any error, and therefore BOSH just hangs waiting for a reply from the server. 

Therefore, we implement server-side timeouts ([https://learn.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-blob-service-operations](https://learn.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-blob-service-operations)) so that Azure responds with an error after the set timeout, and then the next BOSH retry should take over.