### PR TITLE
Do not add `\n` in the end of signed_url

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func main() {
 			log.Fatalf("Failed to sign request: %s", err)
 		}
 
-		fmt.Println(signedURL)
+		fmt.Print(signedURL)
 		os.Exit(0)
 
 	default:


### PR DESCRIPTION
The Println will add `\n` in the end of signed url, then bosh agent cannot recognise/strip the symbol and return an error:
```
L Error: Action Failed get_task: Task 971861a8-3eeb-4bf6-7b17-86e71496b8c1 result: Applying: Applying job nats-tls: Applying package prom_scraper for job nats-tls: Fetching package blob: Failed to download blob: Creating Get Request: parse "https://detached.blob.core.windows.net/director-blobstore/a6c2079c-ec9e-4902-b2f5-3b1ebb26b2a4?se=2024-01-31T12%3A12%3A14Z&sig=gw0st62TBWDUo30przPqhTXTghbOfFbclBYVUOUpsiA%3D&sp=rc&sr=b&sv=2021-12-02&timeout=1800\n": net/url: invalid control character in URL
```
In [S3CLI implementation](https://github.com/cloudfoundry/bosh-s3cli/blob/73f95aab5679f7050b9a4b547d2eeb191f7e14b4/main.go#L124) it simply uses fmt.Print.