### PR TITLE
Support non-public Azure Clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Given a JSON config file (`config.json`)...
 ```
 
 ### Using signed urls with curl
+
 ``` bash
 # Uploading a blob:
 curl -X PUT -H "x-ms-blob-type: blockblob" -F 'fileX=<path/to/file>' <signed url>
@@ -48,13 +49,35 @@ curl -X PUT -H "x-ms-blob-type: blockblob" -F 'fileX=<path/to/file>' <signed url
 curl -X GET <signed url>
 ```
 
-## Running integration tests
+## Running tests
 
-To run the integration tests:
-- Export the following variables into your environment:
-  ``` bash
-  export ACCOUNT_NAME=<your Azure accounnt name>
-  export ACCOUNT_KEY=<your Azure account key>
-  export CONTAINER_NAME=<the target container name>
-  ```
-- go test ./integration/...
+### Unit tests
+
+Using ginkgo:
+
+``` bash
+go install github.com/onsi/ginkgo/v2/ginkgo
+ginkgo --skip-package=integration --randomize-all --cover -v -r
+```
+
+Using go test:
+
+``` bash
+go test $(go list ./... | grep -v integration)
+```
+
+### Integration tests
+
+1. Export the following variables into your environment:
+
+    ``` bash
+    export ACCOUNT_NAME=<your Azure accounnt name>
+    export ACCOUNT_KEY=<your Azure account key>
+    export CONTAINER_NAME=<the target container name>
+    ```
+
+2. Run integration tests
+
+    ```bash
+    go test ./integration/...
+    ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Given a JSON config file (`config.json`)...
 {
   "account_name":           "<string> (required)",
   "account_key":            "<string> (required)",
-  "container_name":         "<string> (required)"
+  "container_name":         "<string> (required)",
+  "environment":            "<string> (optional, default: 'AzureCloud')",
 }
 ```
 

--- a/client/client.go
+++ b/client/client.go
@@ -20,7 +20,7 @@ func New(storageClient StorageClient) (AzBlobstore, error) {
 }
 
 func (client *AzBlobstore) Put(sourceFilePath string, dest string) error {
-	sourceMD5, err:= client.getMD5(sourceFilePath)
+	sourceMD5, err := client.getMD5(sourceFilePath)
 	if err != nil {
 		return err
 	}
@@ -77,7 +77,6 @@ func (client *AzBlobstore) Sign(dest string, action string, expiration time.Dura
 	}
 }
 
-
 func (client *AzBlobstore) getMD5(filePath string) ([]byte, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -85,7 +84,6 @@ func (client *AzBlobstore) getMD5(filePath string) ([]byte, error) {
 	}
 
 	defer file.Close()
-
 
 	hash := md5.New()
 	_, err = io.Copy(hash, file)

--- a/client/storage_client.go
+++ b/client/storage_client.go
@@ -3,8 +3,6 @@ package client
 import (
 	"context"
 	"fmt"
-	azBlob "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 	"io"
 	"log"
 	"os"
@@ -12,7 +10,9 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	azBlob "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 	"github.com/cloudfoundry/bosh-azure-storage-cli/config"
 )
 
@@ -55,7 +55,7 @@ func NewStorageClient(storageConfig config.AZStorageConfig) (StorageClient, erro
 		return nil, err
 	}
 
-	serviceURL := fmt.Sprintf("https://%s.blob.core.windows.net/%s", storageConfig.AccountName, storageConfig.ContainerName)
+	serviceURL := fmt.Sprintf("https://%s.%s/%s", storageConfig.AccountName, storageConfig.StorageEndpoint(), storageConfig.ContainerName)
 
 	return DefaultStorageClient{credential: credential, serviceURL: serviceURL, storageConfig: storageConfig}, nil
 }
@@ -178,8 +178,8 @@ func (dsc DefaultStorageClient) SignedUrl(
 	if requestType == "GET" {
 		url += "&timeout=1800"
 	} else {
-        url += "&timeout=2700"
-    }
+		url += "&timeout=2700"
+	}
 
 	return url, err
 }

--- a/config/config.go
+++ b/config/config.go
@@ -2,13 +2,35 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 )
+
+const storage cloud.ServiceName = "storage"
+
+var cloudConfig cloud.Configuration
+
+func init() {
+	// Configure the cloud endpoints for the storage service
+	// as the SDK does not have a configuration for it
+	cloud.AzurePublic.Services[storage] = cloud.ServiceConfiguration{
+		Endpoint: "blob.core.windows.net",
+	}
+	cloud.AzureChina.Services[storage] = cloud.ServiceConfiguration{
+		Endpoint: "blob.core.chinacloudapi.cn",
+	}
+	cloud.AzureGovernment.Services[storage] = cloud.ServiceConfiguration{
+		Endpoint: "blob.core.usgovcloudapi.net",
+	}
+}
 
 type AZStorageConfig struct {
 	AccountName   string `json:"account_name"`
 	AccountKey    string `json:"account_key"`
 	ContainerName string `json:"container_name"`
+	Environment   string `json:"environment"`
 }
 
 // NewFromReader returns a new azure-storage-cli configuration struct from the contents of reader.
@@ -25,5 +47,29 @@ func NewFromReader(reader io.Reader) (AZStorageConfig, error) {
 		return AZStorageConfig{}, err
 	}
 
+	err = config.configureCloud()
+	if err != nil {
+		return AZStorageConfig{}, err
+	}
+
 	return config, nil
+}
+
+func (c AZStorageConfig) StorageEndpoint() string {
+	return cloudConfig.Services[storage].Endpoint
+}
+
+func (c *AZStorageConfig) configureCloud() error {
+	switch c.Environment {
+	case "AzureCloud", "":
+		c.Environment = "AzureCloud"
+		cloudConfig = cloud.AzurePublic
+	case "AzureChinaCloud":
+		cloudConfig = cloud.AzureChina
+	case "AzureUSGovernment":
+		cloudConfig = cloud.AzureGovernment
+	default:
+		return errors.New("unknown cloud environment: " + c.Environment)
+	}
+	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,8 @@ var _ = Describe("Config", func() {
 		Expect(config.AccountName).To(Equal("foo-account-name"))
 		Expect(config.AccountKey).To(Equal("bar-account-key"))
 		Expect(config.ContainerName).To(Equal("baz-container-name"))
+		Expect(config.Environment).To(Equal("AzureCloud"))
+		Expect(config.StorageEndpoint()).To(Equal("blob.core.windows.net"))
 	})
 
 	It("is empty if config cannot be parsed", func() {
@@ -44,6 +46,45 @@ var _ = Describe("Config", func() {
 		})
 	})
 
+	Context("environment", func() {
+		When("environment is invalid", func() {
+			It("returns an error", func() {
+				configJson := []byte(`{"environment": "invalid-cloud"}`)
+				configReader := bytes.NewReader(configJson)
+
+				config, err := config.NewFromReader(configReader)
+
+				Expect(err.Error()).To(Equal("unknown cloud environment: invalid-cloud"))
+				Expect(config.Environment).Should(BeEmpty())
+			})
+		})
+
+		When("environment is AzureChinaCloud", func() {
+			It("sets the endpoint for china", func() {
+				configJson := []byte(`{"environment": "AzureChinaCloud"}`)
+				configReader := bytes.NewReader(configJson)
+
+				config, err := config.NewFromReader(configReader)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Environment).To(Equal("AzureChinaCloud"))
+				Expect(config.StorageEndpoint()).To(Equal("blob.core.chinacloudapi.cn"))
+			})
+		})
+
+		When("environment is AzureUSGovernment", func() {
+			It("sets the endpoint for usgovernment", func() {
+				configJson := []byte(`{"environment": "AzureUSGovernment"}`)
+				configReader := bytes.NewReader(configJson)
+
+				config, err := config.NewFromReader(configReader)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(config.Environment).To(Equal("AzureUSGovernment"))
+				Expect(config.StorageEndpoint()).To(Equal("blob.core.usgovcloudapi.net"))
+			})
+		})
+	})
 })
 
 type explodingReader struct{}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cloudfoundry/bosh-azure-storage-cli
 go 1.21.0
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.13.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.4.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.8.1
 	github.com/onsi/ginkgo/v2 v2.20.0

--- a/integration/assertions.go
+++ b/integration/assertions.go
@@ -84,7 +84,7 @@ func AssertOnSignedURLs(cliPath string, cfg *config.AZStorageConfig) {
 	configPath := MakeConfigFile(cfg)
 	defer func() { _ = os.Remove(configPath) }()
 
-	regex := "https://"+cfg.AccountName+".blob.core.windows.net/" +cfg.ContainerName +"/some-blob.*"
+	regex := "https://" + cfg.AccountName + ".blob.*/" + cfg.ContainerName + "/some-blob.*"
 
 	cliSession, err := RunCli(cliPath, configPath, "sign", "some-blob", "get", "60s")
 	Expect(err).ToNot(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -139,4 +139,3 @@ func fatalLog(cmd string, err error) {
 		log.Fatalf("performing operation %s: %s\n", cmd, err)
 	}
 }
-


### PR DESCRIPTION
This change allows the bosh-azure-storage-cli to handle objects in Azure Storage Accounts within Azure Clouds that are non-public, such as AzureChinaCloud.

Relates to: https://github.com/cloudfoundry/bosh/issues/2544