### PR TITLE
Improve error handling in Download method

### DIFF
--- a/client/storage_client.go
+++ b/client/storage_client.go
@@ -91,6 +91,9 @@ func (dsc DefaultStorageClient) Download(
 	}
 
 	blobSize, err := client.DownloadFile(context.Background(), dest, nil) //nolint:ineffassign,staticcheck
+	if err != nil {
+		return err
+	}
 	info, err := dest.Stat()
 	if err != nil {
 		return err
@@ -100,7 +103,7 @@ func (dsc DefaultStorageClient) Download(
 		dest.Truncate(blobSize) //nolint:errcheck
 	}
 
-	return err
+	return nil
 }
 
 func (dsc DefaultStorageClient) Delete(


### PR DESCRIPTION
Add additional error handling to the Download method in ```DefaultStorageClient```, so we do not ignore the error which is returned by ```DownloadFile()```. Ignoring it led to exit 0 in case of downloading a non existent file. Now it exits with exit code ```1``` if you download a file that does not exist and prints out the error
```
--------------------------------------------------------------------------------
RESPONSE 404: 404 The specified blob does not exist.
ERROR CODE: BlobNotFound
--------------------------------------------------------------------------------
Response contained no body
--------------------------------------------------------------------------------
```
This fixes https://github.com/cloudfoundry/bosh-azure-storage-cli/issues/17
