### PR TITLE
Extend bosh-azure-storage-cli: new blob commands + upload timeout

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -112,3 +112,8 @@ func (client *AzBlobstore) Properties(dest string) error {
 
 	return client.storageClient.Properties(dest)
 }
+
+func (client *AzBlobstore) EnsureContainerExists() error {
+
+	return client.storageClient.EnsureContainerExists()
+}

--- a/client/client.go
+++ b/client/client.go
@@ -93,3 +93,7 @@ func (client *AzBlobstore) getMD5(filePath string) ([]byte, error) {
 
 	return hash.Sum(nil), nil
 }
+
+func (client *AzBlobstore) List(prefix string) ([]string, error) {
+	return client.storageClient.List(prefix)
+}

--- a/client/client.go
+++ b/client/client.go
@@ -107,3 +107,8 @@ func (client *AzBlobstore) Copy(srcBlob string, dstBlob string) error {
 
 	return client.storageClient.Copy(srcBlob, dstBlob)
 }
+
+func (client *AzBlobstore) Properties(dest string) error {
+
+	return client.storageClient.Properties(dest)
+}

--- a/client/client.go
+++ b/client/client.go
@@ -62,6 +62,11 @@ func (client *AzBlobstore) Delete(dest string) error {
 	return client.storageClient.Delete(dest)
 }
 
+func (client *AzBlobstore) DeleteRecursive(prefix string) error {
+
+	return client.storageClient.DeleteRecursive(prefix)
+}
+
 func (client *AzBlobstore) Exists(dest string) (bool, error) {
 
 	return client.storageClient.Exists(dest)
@@ -96,4 +101,9 @@ func (client *AzBlobstore) getMD5(filePath string) ([]byte, error) {
 
 func (client *AzBlobstore) List(prefix string) ([]string, error) {
 	return client.storageClient.List(prefix)
+}
+
+func (client *AzBlobstore) Copy(srcBlob string, dstBlob string) error {
+
+	return client.storageClient.Copy(srcBlob, dstBlob)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -174,4 +174,45 @@ var _ = Describe("Client", func() {
 		})
 	})
 
+	Context("list", func() {
+		It("lists blobs in a container", func() {
+			storageClient := clientfakes.FakeStorageClient{}
+			storageClient.ListReturns([]string{"blob1", "blob2"}, nil)
+
+			azBlobstore, _ := client.New(&storageClient) //nolint:errcheck
+			blobs, err := azBlobstore.List("")
+			Expect(blobs).To(Equal([]string{"blob1", "blob2"}))
+			Expect(err).ToNot(HaveOccurred())
+
+			containerName := storageClient.ListArgsForCall(0)
+			Expect(containerName).To(Equal(""))
+		})
+
+		It("lists blobs with a prefix in a container", func() {
+			storageClient := clientfakes.FakeStorageClient{}
+			storageClient.ListReturns([]string{"pre-blob1", "pre-blob2"}, nil)
+
+			azBlobstore, _ := client.New(&storageClient) //nolint:errcheck
+			blobs, err := azBlobstore.List("pre-")
+			Expect(blobs).To(Equal([]string{"pre-blob1", "pre-blob2"}))
+			Expect(err).ToNot(HaveOccurred())
+
+			containerName := storageClient.ListArgsForCall(0)
+			Expect(containerName).To(Equal("pre-"))
+		})
+
+		It("returns an error if listing fails", func() {
+			storageClient := clientfakes.FakeStorageClient{}
+			storageClient.ListReturns(nil, errors.New("boom"))
+
+			azBlobstore, _ := client.New(&storageClient) //nolint:errcheck
+			blobs, err := azBlobstore.List("container")
+			Expect(blobs).To(BeNil())
+			Expect(err).To(HaveOccurred())
+
+			containerName := storageClient.ListArgsForCall(0)
+			Expect(containerName).To(Equal("container"))
+		})
+	})
+
 })

--- a/client/clientfakes/fake_storage_client.go
+++ b/client/clientfakes/fake_storage_client.go
@@ -57,6 +57,16 @@ type FakeStorageClient struct {
 	downloadReturnsOnCall map[int]struct {
 		result1 error
 	}
+	EnsureContainerExistsStub        func() error
+	ensureContainerExistsMutex       sync.RWMutex
+	ensureContainerExistsArgsForCall []struct {
+	}
+	ensureContainerExistsReturns struct {
+		result1 error
+	}
+	ensureContainerExistsReturnsOnCall map[int]struct {
+		result1 error
+	}
 	ExistsStub        func(string) (bool, error)
 	existsMutex       sync.RWMutex
 	existsArgsForCall []struct {
@@ -369,6 +379,59 @@ func (fake *FakeStorageClient) DownloadReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.downloadReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStorageClient) EnsureContainerExists() error {
+	fake.ensureContainerExistsMutex.Lock()
+	ret, specificReturn := fake.ensureContainerExistsReturnsOnCall[len(fake.ensureContainerExistsArgsForCall)]
+	fake.ensureContainerExistsArgsForCall = append(fake.ensureContainerExistsArgsForCall, struct {
+	}{})
+	stub := fake.EnsureContainerExistsStub
+	fakeReturns := fake.ensureContainerExistsReturns
+	fake.recordInvocation("EnsureContainerExists", []interface{}{})
+	fake.ensureContainerExistsMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStorageClient) EnsureContainerExistsCallCount() int {
+	fake.ensureContainerExistsMutex.RLock()
+	defer fake.ensureContainerExistsMutex.RUnlock()
+	return len(fake.ensureContainerExistsArgsForCall)
+}
+
+func (fake *FakeStorageClient) EnsureContainerExistsCalls(stub func() error) {
+	fake.ensureContainerExistsMutex.Lock()
+	defer fake.ensureContainerExistsMutex.Unlock()
+	fake.EnsureContainerExistsStub = stub
+}
+
+func (fake *FakeStorageClient) EnsureContainerExistsReturns(result1 error) {
+	fake.ensureContainerExistsMutex.Lock()
+	defer fake.ensureContainerExistsMutex.Unlock()
+	fake.EnsureContainerExistsStub = nil
+	fake.ensureContainerExistsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStorageClient) EnsureContainerExistsReturnsOnCall(i int, result1 error) {
+	fake.ensureContainerExistsMutex.Lock()
+	defer fake.ensureContainerExistsMutex.Unlock()
+	fake.EnsureContainerExistsStub = nil
+	if fake.ensureContainerExistsReturnsOnCall == nil {
+		fake.ensureContainerExistsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.ensureContainerExistsReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -704,6 +767,8 @@ func (fake *FakeStorageClient) Invocations() map[string][][]interface{} {
 	defer fake.deleteRecursiveMutex.RUnlock()
 	fake.downloadMutex.RLock()
 	defer fake.downloadMutex.RUnlock()
+	fake.ensureContainerExistsMutex.RLock()
+	defer fake.ensureContainerExistsMutex.RUnlock()
 	fake.existsMutex.RLock()
 	defer fake.existsMutex.RUnlock()
 	fake.listMutex.RLock()

--- a/client/clientfakes/fake_storage_client.go
+++ b/client/clientfakes/fake_storage_client.go
@@ -83,6 +83,17 @@ type FakeStorageClient struct {
 		result1 []string
 		result2 error
 	}
+	PropertiesStub        func(string) error
+	propertiesMutex       sync.RWMutex
+	propertiesArgsForCall []struct {
+		arg1 string
+	}
+	propertiesReturns struct {
+		result1 error
+	}
+	propertiesReturnsOnCall map[int]struct {
+		result1 error
+	}
 	SignedUrlStub        func(string, string, time.Duration) (string, error)
 	signedUrlMutex       sync.RWMutex
 	signedUrlArgsForCall []struct {
@@ -490,6 +501,67 @@ func (fake *FakeStorageClient) ListReturnsOnCall(i int, result1 []string, result
 	}{result1, result2}
 }
 
+func (fake *FakeStorageClient) Properties(arg1 string) error {
+	fake.propertiesMutex.Lock()
+	ret, specificReturn := fake.propertiesReturnsOnCall[len(fake.propertiesArgsForCall)]
+	fake.propertiesArgsForCall = append(fake.propertiesArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.PropertiesStub
+	fakeReturns := fake.propertiesReturns
+	fake.recordInvocation("Properties", []interface{}{arg1})
+	fake.propertiesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStorageClient) PropertiesCallCount() int {
+	fake.propertiesMutex.RLock()
+	defer fake.propertiesMutex.RUnlock()
+	return len(fake.propertiesArgsForCall)
+}
+
+func (fake *FakeStorageClient) PropertiesCalls(stub func(string) error) {
+	fake.propertiesMutex.Lock()
+	defer fake.propertiesMutex.Unlock()
+	fake.PropertiesStub = stub
+}
+
+func (fake *FakeStorageClient) PropertiesArgsForCall(i int) string {
+	fake.propertiesMutex.RLock()
+	defer fake.propertiesMutex.RUnlock()
+	argsForCall := fake.propertiesArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStorageClient) PropertiesReturns(result1 error) {
+	fake.propertiesMutex.Lock()
+	defer fake.propertiesMutex.Unlock()
+	fake.PropertiesStub = nil
+	fake.propertiesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStorageClient) PropertiesReturnsOnCall(i int, result1 error) {
+	fake.propertiesMutex.Lock()
+	defer fake.propertiesMutex.Unlock()
+	fake.PropertiesStub = nil
+	if fake.propertiesReturnsOnCall == nil {
+		fake.propertiesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.propertiesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeStorageClient) SignedUrl(arg1 string, arg2 string, arg3 time.Duration) (string, error) {
 	fake.signedUrlMutex.Lock()
 	ret, specificReturn := fake.signedUrlReturnsOnCall[len(fake.signedUrlArgsForCall)]
@@ -636,6 +708,8 @@ func (fake *FakeStorageClient) Invocations() map[string][][]interface{} {
 	defer fake.existsMutex.RUnlock()
 	fake.listMutex.RLock()
 	defer fake.listMutex.RUnlock()
+	fake.propertiesMutex.RLock()
+	defer fake.propertiesMutex.RUnlock()
 	fake.signedUrlMutex.RLock()
 	defer fake.signedUrlMutex.RUnlock()
 	fake.uploadMutex.RLock()

--- a/client/clientfakes/fake_storage_client.go
+++ b/client/clientfakes/fake_storage_client.go
@@ -47,6 +47,19 @@ type FakeStorageClient struct {
 		result1 bool
 		result2 error
 	}
+	ListStub        func(string) ([]string, error)
+	listMutex       sync.RWMutex
+	listArgsForCall []struct {
+		arg1 string
+	}
+	listReturns struct {
+		result1 []string
+		result2 error
+	}
+	listReturnsOnCall map[int]struct {
+		result1 []string
+		result2 error
+	}
 	SignedUrlStub        func(string, string, time.Duration) (string, error)
 	signedUrlMutex       sync.RWMutex
 	signedUrlArgsForCall []struct {
@@ -267,6 +280,70 @@ func (fake *FakeStorageClient) ExistsReturnsOnCall(i int, result1 bool, result2 
 	}{result1, result2}
 }
 
+func (fake *FakeStorageClient) List(arg1 string) ([]string, error) {
+	fake.listMutex.Lock()
+	ret, specificReturn := fake.listReturnsOnCall[len(fake.listArgsForCall)]
+	fake.listArgsForCall = append(fake.listArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ListStub
+	fakeReturns := fake.listReturns
+	fake.recordInvocation("List", []interface{}{arg1})
+	fake.listMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeStorageClient) ListCallCount() int {
+	fake.listMutex.RLock()
+	defer fake.listMutex.RUnlock()
+	return len(fake.listArgsForCall)
+}
+
+func (fake *FakeStorageClient) ListCalls(stub func(string) ([]string, error)) {
+	fake.listMutex.Lock()
+	defer fake.listMutex.Unlock()
+	fake.ListStub = stub
+}
+
+func (fake *FakeStorageClient) ListArgsForCall(i int) string {
+	fake.listMutex.RLock()
+	defer fake.listMutex.RUnlock()
+	argsForCall := fake.listArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStorageClient) ListReturns(result1 []string, result2 error) {
+	fake.listMutex.Lock()
+	defer fake.listMutex.Unlock()
+	fake.ListStub = nil
+	fake.listReturns = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeStorageClient) ListReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listMutex.Lock()
+	defer fake.listMutex.Unlock()
+	fake.ListStub = nil
+	if fake.listReturnsOnCall == nil {
+		fake.listReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.listReturnsOnCall[i] = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeStorageClient) SignedUrl(arg1 string, arg2 string, arg3 time.Duration) (string, error) {
 	fake.signedUrlMutex.Lock()
 	ret, specificReturn := fake.signedUrlReturnsOnCall[len(fake.signedUrlArgsForCall)]
@@ -407,6 +484,8 @@ func (fake *FakeStorageClient) Invocations() map[string][][]interface{} {
 	defer fake.downloadMutex.RUnlock()
 	fake.existsMutex.RLock()
 	defer fake.existsMutex.RUnlock()
+	fake.listMutex.RLock()
+	defer fake.listMutex.RUnlock()
 	fake.signedUrlMutex.RLock()
 	defer fake.signedUrlMutex.RUnlock()
 	fake.uploadMutex.RLock()

--- a/client/clientfakes/fake_storage_client.go
+++ b/client/clientfakes/fake_storage_client.go
@@ -11,6 +11,18 @@ import (
 )
 
 type FakeStorageClient struct {
+	CopyStub        func(string, string) error
+	copyMutex       sync.RWMutex
+	copyArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	copyReturns struct {
+		result1 error
+	}
+	copyReturnsOnCall map[int]struct {
+		result1 error
+	}
 	DeleteStub        func(string) error
 	deleteMutex       sync.RWMutex
 	deleteArgsForCall []struct {
@@ -20,6 +32,17 @@ type FakeStorageClient struct {
 		result1 error
 	}
 	deleteReturnsOnCall map[int]struct {
+		result1 error
+	}
+	DeleteRecursiveStub        func(string) error
+	deleteRecursiveMutex       sync.RWMutex
+	deleteRecursiveArgsForCall []struct {
+		arg1 string
+	}
+	deleteRecursiveReturns struct {
+		result1 error
+	}
+	deleteRecursiveReturnsOnCall map[int]struct {
 		result1 error
 	}
 	DownloadStub        func(string, *os.File) error
@@ -93,6 +116,68 @@ type FakeStorageClient struct {
 	invocationsMutex sync.RWMutex
 }
 
+func (fake *FakeStorageClient) Copy(arg1 string, arg2 string) error {
+	fake.copyMutex.Lock()
+	ret, specificReturn := fake.copyReturnsOnCall[len(fake.copyArgsForCall)]
+	fake.copyArgsForCall = append(fake.copyArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.CopyStub
+	fakeReturns := fake.copyReturns
+	fake.recordInvocation("Copy", []interface{}{arg1, arg2})
+	fake.copyMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStorageClient) CopyCallCount() int {
+	fake.copyMutex.RLock()
+	defer fake.copyMutex.RUnlock()
+	return len(fake.copyArgsForCall)
+}
+
+func (fake *FakeStorageClient) CopyCalls(stub func(string, string) error) {
+	fake.copyMutex.Lock()
+	defer fake.copyMutex.Unlock()
+	fake.CopyStub = stub
+}
+
+func (fake *FakeStorageClient) CopyArgsForCall(i int) (string, string) {
+	fake.copyMutex.RLock()
+	defer fake.copyMutex.RUnlock()
+	argsForCall := fake.copyArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeStorageClient) CopyReturns(result1 error) {
+	fake.copyMutex.Lock()
+	defer fake.copyMutex.Unlock()
+	fake.CopyStub = nil
+	fake.copyReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStorageClient) CopyReturnsOnCall(i int, result1 error) {
+	fake.copyMutex.Lock()
+	defer fake.copyMutex.Unlock()
+	fake.CopyStub = nil
+	if fake.copyReturnsOnCall == nil {
+		fake.copyReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.copyReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeStorageClient) Delete(arg1 string) error {
 	fake.deleteMutex.Lock()
 	ret, specificReturn := fake.deleteReturnsOnCall[len(fake.deleteArgsForCall)]
@@ -150,6 +235,67 @@ func (fake *FakeStorageClient) DeleteReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.deleteReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStorageClient) DeleteRecursive(arg1 string) error {
+	fake.deleteRecursiveMutex.Lock()
+	ret, specificReturn := fake.deleteRecursiveReturnsOnCall[len(fake.deleteRecursiveArgsForCall)]
+	fake.deleteRecursiveArgsForCall = append(fake.deleteRecursiveArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.DeleteRecursiveStub
+	fakeReturns := fake.deleteRecursiveReturns
+	fake.recordInvocation("DeleteRecursive", []interface{}{arg1})
+	fake.deleteRecursiveMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeStorageClient) DeleteRecursiveCallCount() int {
+	fake.deleteRecursiveMutex.RLock()
+	defer fake.deleteRecursiveMutex.RUnlock()
+	return len(fake.deleteRecursiveArgsForCall)
+}
+
+func (fake *FakeStorageClient) DeleteRecursiveCalls(stub func(string) error) {
+	fake.deleteRecursiveMutex.Lock()
+	defer fake.deleteRecursiveMutex.Unlock()
+	fake.DeleteRecursiveStub = stub
+}
+
+func (fake *FakeStorageClient) DeleteRecursiveArgsForCall(i int) string {
+	fake.deleteRecursiveMutex.RLock()
+	defer fake.deleteRecursiveMutex.RUnlock()
+	argsForCall := fake.deleteRecursiveArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeStorageClient) DeleteRecursiveReturns(result1 error) {
+	fake.deleteRecursiveMutex.Lock()
+	defer fake.deleteRecursiveMutex.Unlock()
+	fake.DeleteRecursiveStub = nil
+	fake.deleteRecursiveReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeStorageClient) DeleteRecursiveReturnsOnCall(i int, result1 error) {
+	fake.deleteRecursiveMutex.Lock()
+	defer fake.deleteRecursiveMutex.Unlock()
+	fake.DeleteRecursiveStub = nil
+	if fake.deleteRecursiveReturnsOnCall == nil {
+		fake.deleteRecursiveReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteRecursiveReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -478,8 +624,12 @@ func (fake *FakeStorageClient) UploadReturnsOnCall(i int, result1 []byte, result
 func (fake *FakeStorageClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.copyMutex.RLock()
+	defer fake.copyMutex.RUnlock()
 	fake.deleteMutex.RLock()
 	defer fake.deleteMutex.RUnlock()
+	fake.deleteRecursiveMutex.RLock()
+	defer fake.deleteRecursiveMutex.RUnlock()
 	fake.downloadMutex.RLock()
 	defer fake.downloadMutex.RUnlock()
 	fake.existsMutex.RLock()

--- a/client/storage_client.go
+++ b/client/storage_client.go
@@ -119,6 +119,7 @@ func (dsc DefaultStorageClient) Upload(
 	}
 	return uploadResponse.ContentMD5, err
 }
+
 func (dsc DefaultStorageClient) Download(
 	source string,
 	dest *os.File,

--- a/client/storage_client.go
+++ b/client/storage_client.go
@@ -346,7 +346,6 @@ type BlobProperties struct {
 func (dsc DefaultStorageClient) Properties(
 	dest string,
 ) error {
-
 	blobURL := fmt.Sprintf("%s/%s", dsc.serviceURL, dest)
 
 	log.Println(fmt.Sprintf("Getting properties for blob %s", blobURL)) //nolint:staticcheck
@@ -357,6 +356,10 @@ func (dsc DefaultStorageClient) Properties(
 
 	resp, err := client.GetProperties(context.Background(), nil)
 	if err != nil {
+		if strings.Contains(err.Error(), "RESPONSE 404") {
+			fmt.Println(`{}`)
+			return nil
+		}
 		return fmt.Errorf("failed to get properties for blob %s: %w", dest, err)
 	}
 

--- a/client/storage_client.go
+++ b/client/storage_client.go
@@ -17,7 +17,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	azBlob "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
-	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	azContainer "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
 
@@ -232,7 +231,7 @@ func (dsc DefaultStorageClient) DeleteRecursive(
 		return fmt.Errorf("failed to create container client: %w", err)
 	}
 
-	options := &container.ListBlobsFlatOptions{}
+	options := &azContainer.ListBlobsFlatOptions{}
 	if prefix != "" {
 		options.Prefix = &prefix
 	}
@@ -335,7 +334,7 @@ func (dsc DefaultStorageClient) List(
 		return nil, fmt.Errorf("failed to create container client: %w", err)
 	}
 
-	options := &container.ListBlobsFlatOptions{}
+	options := &azContainer.ListBlobsFlatOptions{}
 	if prefix != "" {
 		options.Prefix = &prefix
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type AZStorageConfig struct {
 	AccountKey    string `json:"account_key"`
 	ContainerName string `json:"container_name"`
 	Environment   string `json:"environment"`
+	Timeout       string `json:"timeout_in_seconds"`
 }
 
 // NewFromReader returns a new azure-storage-cli configuration struct from the contents of reader.

--- a/config/config.go
+++ b/config/config.go
@@ -31,7 +31,7 @@ type AZStorageConfig struct {
 	AccountKey    string `json:"account_key"`
 	ContainerName string `json:"container_name"`
 	Environment   string `json:"environment"`
-	Timeout       string `json:"timeout_in_seconds"`
+	Timeout       string `json:"put_timeout_in_seconds"`
 }
 
 // NewFromReader returns a new azure-storage-cli configuration struct from the contents of reader.

--- a/integration/assertions.go
+++ b/integration/assertions.go
@@ -28,6 +28,15 @@ func AssertLifecycleWorks(cliPath string, cfg *config.AZStorageConfig) {
 	Expect(cliSession.ExitCode()).To(BeZero())
 	Expect(cliSession.Err.Contents()).To(MatchRegexp("File '.*' exists in bucket '.*'"))
 
+	// Check blob properties
+	cliSession, err = RunCli(cliPath, configPath, "properties", blobName)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cliSession.ExitCode()).To(BeZero())
+	output := string(cliSession.Out.Contents())
+	Expect(output).To(MatchRegexp(`"etag":\s*".+?"`))
+	Expect(output).To(MatchRegexp(`"last_modified":\s*".+?"`))
+	Expect(output).To(MatchRegexp(`"content_length":\s*\d+`))
+
 	tmpLocalFile, err := os.CreateTemp("", "azure-storage-cli-download")
 	Expect(err).ToNot(HaveOccurred())
 	err = tmpLocalFile.Close()

--- a/integration/assertions.go
+++ b/integration/assertions.go
@@ -64,6 +64,11 @@ func AssertLifecycleWorks(cliPath string, cfg *config.AZStorageConfig) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cliSession.ExitCode()).To(Equal(3))
 	Expect(cliSession.Err.Contents()).To(MatchRegexp("File '.*' does not exist in bucket '.*'"))
+
+	cliSession, err = RunCli(cliPath, configPath, "properties", blobName)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cliSession.ExitCode()).To(Equal(0))
+	Expect(cliSession.Out.Contents()).To(MatchRegexp("{}"))
 }
 
 func AssertOnCliVersion(cliPath string, cfg *config.AZStorageConfig) {

--- a/integration/assertions.go
+++ b/integration/assertions.go
@@ -13,10 +13,10 @@ func AssertPutUsesDefaultTimeout(cliPath string, cfg *config.AZStorageConfig) {
 	cfg2 := *cfg
 	cfg2.Timeout = "" // triggers default 41s
 	configPath := MakeConfigFile(&cfg2)
-	defer os.Remove(configPath)
+	defer os.Remove(configPath) //nolint:errcheck
 
 	content := MakeContentFile("hello")
-	defer os.Remove(content)
+	defer os.Remove(content) //nolint:errcheck
 	blob := GenerateRandomString()
 
 	sess, err := RunCli(cliPath, configPath, "put", content, blob)
@@ -30,10 +30,10 @@ func AssertPutHonorsCustomTimeout(cliPath string, cfg *config.AZStorageConfig) {
 	cfg2 := *cfg
 	cfg2.Timeout = "3s"
 	configPath := MakeConfigFile(&cfg2)
-	defer os.Remove(configPath)
+	defer os.Remove(configPath) //nolint:errcheck
 
 	content := MakeContentFile("ok")
-	defer os.Remove(content)
+	defer os.Remove(content) //nolint:errcheck
 	blob := GenerateRandomString()
 
 	sess, err := RunCli(cliPath, configPath, "put", content, blob)
@@ -45,10 +45,10 @@ func AssertPutTimesOut(cliPath string, cfg *config.AZStorageConfig) {
 	cfg2 := *cfg
 	cfg2.Timeout = "1ns"
 	configPath := MakeConfigFile(&cfg2)
-	defer os.Remove(configPath)
+	defer os.Remove(configPath) //nolint:errcheck
 
 	content := MakeContentFile("data")
-	defer os.Remove(content)
+	defer os.Remove(content) //nolint:errcheck
 	blob := GenerateRandomString()
 
 	sess, err := RunCli(cliPath, configPath, "put", content, blob)
@@ -61,10 +61,10 @@ func AssertInvalidTimeoutFallsBack(cliPath string, cfg *config.AZStorageConfig) 
 	cfg2 := *cfg
 	cfg2.Timeout = "bananas"
 	configPath := MakeConfigFile(&cfg2)
-	defer os.Remove(configPath)
+	defer os.Remove(configPath) //nolint:errcheck
 
 	content := MakeContentFile("x")
-	defer os.Remove(content)
+	defer os.Remove(content) //nolint:errcheck
 	blob := GenerateRandomString()
 
 	sess, err := RunCli(cliPath, configPath, "put", content, blob)
@@ -76,7 +76,7 @@ func AssertInvalidTimeoutFallsBack(cliPath string, cfg *config.AZStorageConfig) 
 
 func AssertSignedURLTimeouts(cliPath string, cfg *config.AZStorageConfig) {
 	configPath := MakeConfigFile(cfg)
-	defer os.Remove(configPath)
+	defer os.Remove(configPath) //nolint:errcheck
 
 	sess, err := RunCli(cliPath, configPath, "sign", "some-blob", "get", "60s")
 	Expect(err).ToNot(HaveOccurred())
@@ -91,7 +91,7 @@ func AssertSignedURLTimeouts(cliPath string, cfg *config.AZStorageConfig) {
 
 func AssertEnsureBucketIdempotent(cliPath string, cfg *config.AZStorageConfig) {
 	configPath := MakeConfigFile(cfg)
-	defer os.Remove(configPath)
+	defer os.Remove(configPath) //nolint:errcheck
 
 	s1, err := RunCli(cliPath, configPath, "ensure-bucket-exists")
 	Expect(err).ToNot(HaveOccurred())
@@ -104,26 +104,26 @@ func AssertEnsureBucketIdempotent(cliPath string, cfg *config.AZStorageConfig) {
 
 func AssertPutGetWithSpecialNames(cliPath string, cfg *config.AZStorageConfig) {
 	configPath := MakeConfigFile(cfg)
-	defer os.Remove(configPath)
+	defer os.Remove(configPath) //nolint:errcheck
 
 	name := "dir a/üñîçødë file.txt"
 	content := "weird name content"
 	f := MakeContentFile(content)
-	defer os.Remove(f)
+	defer os.Remove(f) //nolint:errcheck
 
 	s, err := RunCli(cliPath, configPath, "put", f, name)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(s.ExitCode()).To(BeZero())
 
-	tmp, _ := os.CreateTemp("", "dl")
-	tmp.Close()
-	defer os.Remove(tmp.Name())
+	tmp, _ := os.CreateTemp("", "dl") //nolint:errcheck
+	tmp.Close()                       //nolint:errcheck
+	defer os.Remove(tmp.Name())       //nolint:errcheck
 
 	s, err = RunCli(cliPath, configPath, "get", name, tmp.Name())
 	Expect(err).ToNot(HaveOccurred())
 	Expect(s.ExitCode()).To(BeZero())
 
-	b, _ := os.ReadFile(tmp.Name())
+	b, _ := os.ReadFile(tmp.Name()) //nolint:errcheck
 	Expect(string(b)).To(Equal(content))
 
 	s, err = RunCli(cliPath, configPath, "delete", name)

--- a/integration/assertions.go
+++ b/integration/assertions.go
@@ -19,7 +19,12 @@ func AssertLifecycleWorks(cliPath string, cfg *config.AZStorageConfig) {
 	contentFile := MakeContentFile(expectedString)
 	defer os.Remove(contentFile) //nolint:errcheck
 
-	cliSession, err := RunCli(cliPath, configPath, "put", contentFile, blobName)
+	// Ensure container/bucket exists
+	cliSession, err := RunCli(cliPath, configPath, "ensure-bucket-exists")
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cliSession.ExitCode()).To(BeZero())
+
+	cliSession, err = RunCli(cliPath, configPath, "put", contentFile, blobName)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(cliSession.ExitCode()).To(BeZero())
 

--- a/integration/assertions.go
+++ b/integration/assertions.go
@@ -211,7 +211,7 @@ func AssertGetNonexistentFails(cliPath string, cfg *config.AZStorageConfig) {
 
 	cliSession, err := RunCli(cliPath, configPath, "get", "non-existent-file", "/dev/null")
 	Expect(err).ToNot(HaveOccurred())
-	Expect(cliSession.ExitCode()).To(BeZero()) // ToDo Not sure why this is returning 0, before it was something else
+	Expect(cliSession.ExitCode()).ToNot(BeZero())
 }
 
 func AssertDeleteNonexistentWorks(cliPath string, cfg *config.AZStorageConfig) {

--- a/integration/general_azure_test.go
+++ b/integration/general_azure_test.go
@@ -49,8 +49,13 @@ var _ = Describe("General testing for all Azure regions", func() {
 		func(cfg *config.AZStorageConfig) { integration.AssertOnSignedURLs(cliPath, cfg) },
 		configurations,
 	)
-	DescribeTable("Invoking 'list' returns a list of blobs",
-		func(cfg *config.AZStorageConfig) { integration.AssertOnList(cliPath, cfg) },
+	DescribeTable("Blobstore list and delete lifecycle works",
+		func(cfg *config.AZStorageConfig) { integration.AssertOnListDeleteLifecyle(cliPath, cfg) },
+		configurations,
+	)
+
+	DescribeTable("Server-side copy works",
+		func(cfg *config.AZStorageConfig) { integration.AssertOnCopy(cliPath, cfg) },
 		configurations,
 	)
 

--- a/integration/general_azure_test.go
+++ b/integration/general_azure_test.go
@@ -49,6 +49,11 @@ var _ = Describe("General testing for all Azure regions", func() {
 		func(cfg *config.AZStorageConfig) { integration.AssertOnSignedURLs(cliPath, cfg) },
 		configurations,
 	)
+	DescribeTable("Invoking 'list' returns a list of blobs",
+		func(cfg *config.AZStorageConfig) { integration.AssertOnList(cliPath, cfg) },
+		configurations,
+	)
+
 	Describe("Invoking `put`", func() {
 		var blobName string
 		var configPath string

--- a/integration/general_azure_test.go
+++ b/integration/general_azure_test.go
@@ -33,8 +33,8 @@ var _ = Describe("General testing for all Azure regions", func() {
 	configurations := []TableEntry{
 		Entry("with default config", &defaultConfig),
 	}
-	DescribeTable("Assert Put Uses Default Timeout",
-		func(cfg *config.AZStorageConfig) { integration.AssertPutUsesDefaultTimeout(cliPath, cfg) },
+	DescribeTable("Assert Put Uses No Timeout When Not Specified",
+		func(cfg *config.AZStorageConfig) { integration.AssertPutUsesNoTimeout(cliPath, cfg) },
 		configurations,
 	)
 	DescribeTable("Assert Put Honors Custom Timeout",
@@ -45,12 +45,20 @@ var _ = Describe("General testing for all Azure regions", func() {
 		func(cfg *config.AZStorageConfig) { integration.AssertPutTimesOut(cliPath, cfg) },
 		configurations,
 	)
-	DescribeTable("Assert Invalid Timeout Falls Back",
-		func(cfg *config.AZStorageConfig) { integration.AssertInvalidTimeoutFallsBack(cliPath, cfg) },
+	DescribeTable("Assert Invalid Timeout Error",
+		func(cfg *config.AZStorageConfig) { integration.AssertInvalidTimeoutIsError(cliPath, cfg) },
 		configurations,
 	)
 	DescribeTable("Assert Signed URL Timeouts",
 		func(cfg *config.AZStorageConfig) { integration.AssertSignedURLTimeouts(cliPath, cfg) },
+		configurations,
+	)
+	DescribeTable("Rejects zero timeout",
+		func(cfg *config.AZStorageConfig) { integration.AssertZeroTimeoutIsError(cliPath, cfg) },
+		configurations,
+	)
+	DescribeTable("Rejects negative timeout",
+		func(cfg *config.AZStorageConfig) { integration.AssertNegativeTimeoutIsError(cliPath, cfg) },
 		configurations,
 	)
 	DescribeTable("Assert Ensure Bucket Idempotent",

--- a/integration/general_azure_test.go
+++ b/integration/general_azure_test.go
@@ -33,6 +33,34 @@ var _ = Describe("General testing for all Azure regions", func() {
 	configurations := []TableEntry{
 		Entry("with default config", &defaultConfig),
 	}
+	DescribeTable("Assert Put Uses Default Timeout",
+		func(cfg *config.AZStorageConfig) { integration.AssertPutUsesDefaultTimeout(cliPath, cfg) },
+		configurations,
+	)
+	DescribeTable("Assert Put Honors Custom Timeout",
+		func(cfg *config.AZStorageConfig) { integration.AssertPutHonorsCustomTimeout(cliPath, cfg) },
+		configurations,
+	)
+	DescribeTable("Assert Put Times Out",
+		func(cfg *config.AZStorageConfig) { integration.AssertPutTimesOut(cliPath, cfg) },
+		configurations,
+	)
+	DescribeTable("Assert Invalid Timeout Falls Back",
+		func(cfg *config.AZStorageConfig) { integration.AssertInvalidTimeoutFallsBack(cliPath, cfg) },
+		configurations,
+	)
+	DescribeTable("Assert Signed URL Timeouts",
+		func(cfg *config.AZStorageConfig) { integration.AssertSignedURLTimeouts(cliPath, cfg) },
+		configurations,
+	)
+	DescribeTable("Assert Ensure Bucket Idempotent",
+		func(cfg *config.AZStorageConfig) { integration.AssertEnsureBucketIdempotent(cliPath, cfg) },
+		configurations,
+	)
+	DescribeTable("Assert Put Get With Special Names",
+		func(cfg *config.AZStorageConfig) { integration.AssertPutGetWithSpecialNames(cliPath, cfg) },
+		configurations,
+	)
 	DescribeTable("Blobstore lifecycle works",
 		func(cfg *config.AZStorageConfig) { integration.AssertLifecycleWorks(cliPath, cfg) },
 		configurations,

--- a/main.go
+++ b/main.go
@@ -45,10 +45,6 @@ func main() {
 	}
 
 	nonFlagArgs := flag.Args()
-	if len(nonFlagArgs) < 2 && nonFlagArgs[0] != "list" {
-		log.Fatalf("Expected at least two arguments got %d\n", len(nonFlagArgs))
-	}
-
 	cmd := nonFlagArgs[0]
 
 	switch cmd {
@@ -83,6 +79,16 @@ func main() {
 		err = blobstoreClient.Get(src, dstFile)
 		fatalLog(cmd, err)
 
+	case "copy":
+		if len(nonFlagArgs) != 3 {
+			log.Fatalf("Get method expected 3 arguments got %d\n", len(nonFlagArgs))
+		}
+
+		srcBlob, dstBlob := nonFlagArgs[1], nonFlagArgs[2]
+
+		err = blobstoreClient.Copy(srcBlob, dstBlob)
+		fatalLog(cmd, err)
+
 	case "delete":
 		if len(nonFlagArgs) != 2 {
 			log.Fatalf("Delete method expected 2 arguments got %d\n", len(nonFlagArgs))
@@ -90,6 +96,18 @@ func main() {
 
 		err = blobstoreClient.Delete(nonFlagArgs[1])
 		fatalLog(cmd, err)
+
+	case "delete-recursive":
+		var prefix string
+		if len(nonFlagArgs) > 2 {
+			log.Fatalf("delete-recursive takes at most one argument (prefix) got %d\n", len(nonFlagArgs)-1)
+		} else if len(nonFlagArgs) == 2 {
+			prefix = nonFlagArgs[1]
+		} else {
+			prefix = ""
+		}
+		err = blobstoreClient.DeleteRecursive(prefix)
+		fatalLog("delete-recursive", err)
 
 	case "exists":
 		if len(nonFlagArgs) != 2 {

--- a/main.go
+++ b/main.go
@@ -177,6 +177,14 @@ func main() {
 		err = blobstoreClient.Properties(nonFlagArgs[1])
 		fatalLog("properties", err)
 
+	case "ensure-bucket-exists":
+		if len(nonFlagArgs) != 1 {
+			log.Fatalf("EnsureBucketExists method expected 1 arguments got %d\n", len(nonFlagArgs))
+		}
+
+		err = blobstoreClient.EnsureContainerExists()
+		fatalLog("ensure-bucket-exists", err)
+
 	default:
 		log.Fatalf("unknown command: '%s'\n", cmd)
 	}

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	}
 
 	nonFlagArgs := flag.Args()
-	if len(nonFlagArgs) < 2 {
+	if len(nonFlagArgs) < 2 && nonFlagArgs[0] != "list" {
 		log.Fatalf("Expected at least two arguments got %d\n", len(nonFlagArgs))
 	}
 
@@ -129,6 +129,27 @@ func main() {
 
 		fmt.Print(signedURL)
 		os.Exit(0)
+
+	case "list":
+		var prefix string
+
+		if len(nonFlagArgs) == 1 {
+			prefix = ""
+		} else if len(nonFlagArgs) == 2 {
+			prefix = nonFlagArgs[1]
+		} else {
+			log.Fatalf("List method expected 1 or 2 arguments, got %d\n", len(nonFlagArgs)-1)
+		}
+
+		var objects []string
+		objects, err = blobstoreClient.List(prefix)
+		if err != nil {
+			log.Fatalf("Failed to list objects: %s", err)
+		}
+
+		for _, object := range objects {
+			fmt.Println(object)
+		}
 
 	default:
 		log.Fatalf("unknown command: '%s'\n", cmd)

--- a/main.go
+++ b/main.go
@@ -169,6 +169,14 @@ func main() {
 			fmt.Println(object)
 		}
 
+	case "properties":
+		if len(nonFlagArgs) != 2 {
+			log.Fatalf("Properties method expected 2 arguments got %d\n", len(nonFlagArgs))
+		}
+
+		err = blobstoreClient.Properties(nonFlagArgs[1])
+		fatalLog("properties", err)
+
 	default:
 		log.Fatalf("unknown command: '%s'\n", cmd)
 	}


### PR DESCRIPTION
1) Add missing commands to bosh-azure-storage-cli:

  - list <prefix>: Lists all blobs - optional under a prefix -> [Draft](https://github.com/johha/bosh-azure-storage-cli/tree/capi)
  - delete <prefix> --recursive: Deletes all blobs for a given prefix
  - copy <src> <dst>: Server-side copy
  - ensure-bucket-exists: ensures bucket exists
  - properties: Retrieve metadata for a given key

2) Add missing Config: timeout for upload as implemented by https://github.com/fog/fog-azure-rm/commit/d7299cd889fcc26d07fdc3681b5144063693659b 

    - Parse and apply configurable timeout for blob uploads, if unset upload without timeout
    - Log invalid timeout values
    - Return specific error if upload times out